### PR TITLE
Uapi version.

### DIFF
--- a/src/Request/uapi-request.js
+++ b/src/Request/uapi-request.js
@@ -107,7 +107,7 @@ module.exports = function (service, auth, reqType, rootObject,
     };
 
     // create a v36 uAPI parser with default params and request data in env
-    const uParser = new UapiParser(rootObject, 'v36_0', params);
+    const uParser = new UapiParser(rootObject, 'v36_0', params, debugMode);
 
     const parseResponse = function (response) {
       // if there are web server or HTTP auth errors, uAPI returns a JSON


### PR DESCRIPTION
- added debug mode to uapi-parser to avoid console.log.
- automatically detecting version of uapi on the step of parsing.
 default version would be 36 and defined in uapi-request.
 after that uapi-parser will make a try to redefine it with response
 version.