### PR TITLE
Fixed timeout as optional param

### DIFF
--- a/src/Services/Terminal/TerminalValidator.js
+++ b/src/Services/Terminal/TerminalValidator.js
@@ -41,7 +41,7 @@ Validator.prototype.sessionToken = function () {
 };
 
 Validator.prototype.timeout = function () {
-  if ((typeof this.params.timeout) !== 'undefined') {
+  if (this.params.timeout !== false) {
     if ((typeof this.params.timeout) !== 'number') {
       throw new TerminalValidationError.SessionTimeoutInvalid(this.params);
     }

--- a/test/Terminal/TerminalValidator.test.js
+++ b/test/Terminal/TerminalValidator.test.js
@@ -15,8 +15,12 @@ describe('#TerminalValidator', () => {
       const fn = () => TerminalValidator.CREATE_SESSION('PARAMS');
       expect(fn).to.throw(uAPI.errors.Terminal.TerminalValidationError.ParamsInvalidType);
     });
-    it('should be ok when no timeout provided in params', () => {
+    it('should fail when no timeout provided in params', () => {
       const fn = () => TerminalValidator.CREATE_SESSION({ SOME: 'PARAMS' });
+      expect(fn).to.throw(uAPI.errors.Terminal.TerminalValidationError.SessionTimeoutInvalid);
+    });
+    it('should be ok when timeout = false provided in params', () => {
+      const fn = () => TerminalValidator.CREATE_SESSION({ timeout: false });
       expect(fn).not.to.throw(Error);
     });
     it('should fail when wrong timeout type is provided', () => {


### PR DESCRIPTION
Fixes #78 

@shmuga , please review

Checking for exact value of `false` instead of `undefined` as if no value is provided timeout is set to `false`.