### PR TITLE
Feature/88 - Terminal use of settings.auth.emulatePcc instead of settings.emulatePcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ It also has several useful helpers to handle errors.
 | auth | `Object <username, password, targetBranch, pcc, emulatePcc>` | - | See `auth` description [below](#auth). |
 | debug | `Number` | `0` | Can be `0`, `1`, or `2`. |
 | production | `Boolean` | `true` | Production variable is connected with production and pre-production environment. Can be true for production and false for pre-production. For more information read docs. |
-| emulatePcc | `String` | - | Optional. Used for `TerminalService` only. See [`TerminalService`](docs/Terminal.md) |
 | timeout | `Number` | - | Optional. Used for `TerminalService` only. See [`TerminalService`](docs/Terminal.md) |
 
 ### Auth object
 <a name="auth"></a>
-`username`, `password`, `targetBranch` and `pcc` should be set in `auth` object and provided by Travelport.
-Optional `emulatePcc` is a PCC on which are transaction executed. This PCC needs to have set SVCB field in the AAT profile.
+`username`, `password`, `targetBranch` and `pcc` should be set in `auth` object and are provided by Travelport.
+Optional `emulatePcc` is a PCC on behalf of which transactions are executed.
+This PCC needs to have set SVCB field in the AAT profile.
 
 There are 3 types of `debug` mode:
 

--- a/docs/Terminal.md
+++ b/docs/Terminal.md
@@ -4,7 +4,8 @@ Terminal service provides an interface to run terminal commands
 for terminal-enabled uAPI credentials.
 
 You can use Terminal service to run commands on behalf of your own PCC
-or to use `emulatePcc` option to run commands on behalf of other PC using your own Service bureau.
+or to use `emulatePcc` option from `auth` to run commands on behalf of other PCC
+using your own Service bureau.
 
 ## API
 

--- a/examples/Terminal/ignore.js
+++ b/examples/Terminal/ignore.js
@@ -1,11 +1,14 @@
 const uAPI = require('../../index');
-const config = require('../../test/testconfig');
+const testConfig = require('../../test/testconfig');
+
+const config = Object.assign({}, testConfig, {
+  emulatePcc: '7j8j',
+});
 
 const TerminalService = uAPI.createTerminalService({
   auth: config,
   debug: 2,
   production: true,
-  emulatePcc: '7j8j',
 });
 
 // BAD EXAMPLE OF USAGE

--- a/examples/Terminal/serial.js
+++ b/examples/Terminal/serial.js
@@ -1,5 +1,9 @@
 const uAPI = require('../../index');
-const config = require('../../test/testconfig');
+const testConfig = require('../../test/testconfig');
+
+const config = Object.assign({}, testConfig, {
+  emulatePcc: '7j8j',
+});
 
 const TerminalService = uAPI.createTerminalService({
   auth: config,

--- a/examples/Terminal/simultaneousError.js
+++ b/examples/Terminal/simultaneousError.js
@@ -1,5 +1,9 @@
 const uAPI = require('../../index');
-const config = require('../../test/testconfig');
+const testConfig = require('../../test/testconfig');
+
+const config = Object.assign({}, testConfig, {
+  emulatePcc: '7j8j',
+});
 
 const TerminalService = uAPI.createTerminalService({
   auth: config,

--- a/src/Services/Terminal/Terminal.js
+++ b/src/Services/Terminal/Terminal.js
@@ -15,7 +15,7 @@ const responseHasMoreData = response => (response.slice(-1).join('') === ')><');
 
 module.exports = function (settings) {
   const service = terminalService(settings);
-  const emulatePcc = settings.emulatePcc || false;
+  const emulatePcc = settings.auth.emulatePcc || false;
   const timeout = settings.timeout || false;
   const state = {
     terminalState: TERMINAL_STATE_NONE,

--- a/test/Terminal/Terminal.test.js
+++ b/test/Terminal/Terminal.test.js
@@ -73,8 +73,11 @@ describe('#Terminal', function terminalTest() {
       closeSession.reset();
 
       const emulatePcc = '7j8i';
+      const emulateConfig = Object.assign({}, config, {
+        emulatePcc,
+      });
       const uAPITerminal = terminal({
-        auth: config,
+        auth: emulateConfig,
         emulatePcc,
       });
 


### PR DESCRIPTION
Closes #88.
Updated:
 - code
 - docs
 - tests
 - examples