### PR TITLE
removes two attributes from air availability request template

### DIFF
--- a/src/Services/Air/templates/AIR_AVAILABILTIY_REQUEST.handlebars.js
+++ b/src/Services/Air/templates/AIR_AVAILABILTIY_REQUEST.handlebars.js
@@ -3,8 +3,6 @@ module.exports = `
     <soap:Body>
         <air:AvailabilitySearchReq
             AuthorizedBy="user" TraceId="{{requestId}}" TargetBranch="{{TargetBranch}}"
-            SolutionResult="true"
-            ReturnBrandedFares="true"
             xmlns:air="http://www.travelport.com/schema/air_v36_0"
             xmlns:com="http://www.travelport.com/schema/common_v36_0"
             >


### PR DESCRIPTION
Below 2 attributes is not allowed for air availability request
 SolutionResult="true"
 ReturnBrandedFares="true"

Passing this cause validation error also I have checked Travelport api doc this attributes not right here.
So I have removed those form air service template file .