### PR TITLE
issue/294 | Update PCC emulation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,21 @@ It also has several useful helpers to handle errors.
 | autoClose | `Boolean` | Optional. Used only in `TerminalService`. Defines if service should make `closeSession` request. |
 | options | `Object` | {} | Optional. User for all services to all additional options like custom log function, etc. See `options` description [bellow](#options). |
 
-<a name="options"></a>
 ### Additional options 
+<a name="options"></a>
 
 `logFunction` - set custom logging function that should match next shape `(...args) => {}`. Will receive all requests and responses from uapi/terminal.
 
 ### Auth object
 <a name="auth"></a>
-`username`, `password` and `targetBranch` should be set in `auth` object and are provided by Travelport.
-Optional `emulatePcc` is a PCC on behalf of which transactions are executed.
-This PCC needs to have set SVCB field in the AAT profile.
-Optional `region` is to select a region, default `emea`.
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+|  username | `String` | - | User name identifier, provided by Travelport. |
+| password | `String` | - | Password for current username, provided by Travelport. |
+| targetBranch | `String` | - | Branch, provided by Travelport. |
+| region | `String` | `emea` | Optional. Used to select region. |
+| emulatePcc | `String/Boolean` | `False` | Optional. A PCC on behalf of which transactions are executed in Air, Hotels, Utils. This PCC needs to have set SVCB field in the AAT profile. Define a PCC if you have a bureau and want to execute transactions on its behalf. Follow this [documentation](docs/Terminal.md#emulatePcc) to take a detailew view of the `emulatePcc` for the Terminal. |
 
 There are 3 types of `debug` mode:
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ It also has several useful helpers to handle errors.
 | password | `String` | - | Password for current username, provided by Travelport. |
 | targetBranch | `String` | - | Branch, provided by Travelport. |
 | region | `String` | `emea` | Optional. Used to select region. |
-| emulatePcc | `String/Boolean` | `False` | Optional. A PCC on behalf of which transactions are executed in Air, Hotels, Utils. This PCC needs to have set SVCB field in the AAT profile. Define a PCC if you have a bureau and want to execute transactions on its behalf. Follow this [documentation](docs/Terminal.md#emulatePcc) to take a detailew view of the `emulatePcc` for the Terminal. |
+| emulatePcc | `String/Boolean` | `False` | Optional. A PCC on behalf of which transactions are executed in Air, Hotels, Utils. This PCC needs to have set SVCB field in the AAT profile. Define a PCC if you have a service bureau and want to execute transactions on behalf of some of its PCCs. Follow this [documentation](docs/Terminal.md#emulatePcc) to take a detailew view of the `emulatePcc` for the Terminal. |
 
 There are 3 types of `debug` mode:
 
@@ -118,7 +118,3 @@ See the following services pages to take a detailed view
 
 # Contributing
 Please visit [CONTRIBUTING.md](/CONTRIBUTING.md)
-
-
-
-

--- a/docs/Terminal.md
+++ b/docs/Terminal.md
@@ -21,63 +21,11 @@ for several PCC emulations.
 See [advanced emulation example](../examples/Terminal/emulation.js) to get an example
 on how to use emulation.
 
+# Session closing
 Be aware to close the session after all your manipulations with the terminal.
 
 Session closing takes the current token and sends a request to terminate the session,
-see [here](#close_session).
-
-Let's see another example with several emulations:
-```javascript
-const auth =  {
-  username: 'Universal API/ХХХХХХХХХХ',
-  password: 'ХХХХХХХХХХ',
-  targetBranch: 'ХХХХХХХ',
-};
-
-// Let's create two instances for two PCCs - ABCD and WXYZ
-const auth_ABCD = {
-  ...auth,
-  emulatePcc: 'ABCD'
-};
-const auth_WXYZ = {
-  ...auth,
-  emulatePcc: 'WXYZ'
-};
-
-// Now, create two terminal instances
-const TerminalServiceABCD = uAPI.createTerminalService({
-  auth: auth_ABCD,
-  debug: 2,
-  production: true,
-});
-const TerminalServiceWXYZ = uAPI.createTerminalService({
-  auth: auth_WXYZ,
-  debug: 2,
-  production: true,
-});
-
-/*
-  At this point, we are having two instances with two different PCCs connected to.
-  Now we're able to execute a command on behalf of both of the PCCs.
-*/
-TerminalServiceABCD
-  .executeCommand('I')
-  .then(console.log)
-  .then(
-    () => TerminalService.closeSession()
-  )
-  .catch(console.error);
-
-TerminalServiceWXYZ
-  .executeCommand('I')
-  .then(console.log)
-  .then(
-    () => TerminalService.closeSession()
-  )
-  .catch(console.error);
-```
-
-More usage examples are [here](../examples/Terminal/).
+see [close_session](#close_session) method.
 
 # API
 

--- a/docs/Terminal.md
+++ b/docs/Terminal.md
@@ -17,10 +17,24 @@ const auth = {
   username: 'Universal API/ХХХХХХХХХХ',
   password: 'ХХХХХХХХХХ',
   targetBranch: 'ХХХХХХХ',
-  emulatePcc: 'ХХХХ',
+  emulatePcc: 'ХХХХ', // Optional
 };
 
-const AirService = uAPI.createAirService({ auth, debug: 2 });
+const TerminalService = uAPI.createTerminalService({
+  auth: auth,
+  debug: 2,
+  production: true,
+});
+
+TerminalService.executeCommand('SEM/TARGET_PCC/AG')
+  .then((res) => {
+    console.log(res);
+    TerminalService.closeSession();
+  })
+  .catch((err) => {
+    console.error(err);
+    TerminalService.closeSession();
+  });
 ```
 
 More usage examples are [here](../examples/Terminal/).

--- a/docs/Terminal.md
+++ b/docs/Terminal.md
@@ -7,61 +7,24 @@ for terminal-enabled uAPI credentials.
 <a name='emulatePcc'></a>
 
 You can use Terminal service to run commands on behalf of your own PCC
-or to use `emulatePcc` option from [auth](../README.md#auth) to run commands on behalf of other PCC
-using your own Service bureau.
+or to use `emulatePcc` option from [auth](../README.md#auth)
+to run commands on behalf of other PCC using your own Service bureau.
 
-Creatin a terminal instance creates a terminal with a token that links to the specific Terminal instance to keep emulation running on one instance.
+In `uapi` terminals are not linked to the specific PCC and identified only by tokens.
+That's why, if the `emulatePcc` option is passed, we run `SEM` command behind the scene
+to provide emulation for specific PCC.
 
-With token assignment if `emulatePcc` is passed, behind the scene - runs command `SEM` to provide emulation of specified PCC.
+Though you may still send `SEM` commands to the terminal on your own,
+in order to not messthings up, we highly recommend you to use several terminal instances
+for several PCC emulations.
 
-To don't mess things up we highly recommend you to use several terminal instances for several PCC emulations.
-
-```javascript
-const auth = {
-  username: 'Universal API/ХХХХХХХХХХ',
-  password: 'ХХХХХХХХХХ',
-  targetBranch: 'ХХХХХХХ',
-  emulatePcc: 'ABCD', // Let's emulate 'ABCD' PCC
-};
-
-/*
-  We create a terminal instance.
-  Behind the scene, it creates a token, credentials, and runs `SEM` to emulate the PCC.
-*/
-const TerminalService = uAPI.createTerminalService({
-  auth: auth,
-  debug: 2,
-  production: true,
-});
-
-/*
-  As soon as we have Terminal instance - we can execute commands on its behalf.
-  All executed commands of the instance will run on PCC's behalf.
-*/
-TerminalService
-  .executeCommand('I')
-  .then(console.log)
-  .then(
-    () => TerminalService.executeCommand('.CDIEV')
-  )
-  .then(console.log)
-  .then(
-    () => TerminalService.executeCommand('.ADPS')
-  )
-  .then(console.log)
-  .then(
-    () => TerminalService.executeCommand('@LT')
-  )
-  .then(console.log)
-  .then(
-    () => TerminalService.closeSession()
-  )
-  .catch(console.error);
-```
+See [advanced emulation example](../examples/Terminal/emulation.js) to get an example
+on how to use emulation.
 
 Be aware to close the session after all your manipulations with the terminal.
 
-Session closing takes the current token and sends a request to terminate the session, see [here](#close_session).
+Session closing takes the current token and sends a request to terminate the session,
+see [here](#close_session).
 
 Let's see another example with several emulations:
 ```javascript

--- a/docs/Terminal.md
+++ b/docs/Terminal.md
@@ -3,9 +3,27 @@
 Terminal service provides an interface to run terminal commands
 for terminal-enabled uAPI credentials.
 
+# PCC Emulation
+<a name='emulatePcc'></a>
+
 You can use Terminal service to run commands on behalf of your own PCC
-or to use `emulatePcc` option from `auth` to run commands on behalf of other PCC
-using your own Service bureau.
+or to use `emulatePcc` option from [auth](../README.md#auth) to run commands on behalf of other PCC
+using your own Service bureau. 
+
+If you logged in with your PCC you're still able to execute a command on behalf of other PCC, just simply switch PCC with the Terminal command `SEM/TARGET_PCC/AG`.
+
+```javascript
+const auth = {
+  username: 'Universal API/ХХХХХХХХХХ',
+  password: 'ХХХХХХХХХХ',
+  targetBranch: 'ХХХХХХХ',
+  emulatePcc: 'ХХХХ',
+};
+
+const AirService = uAPI.createAirService({ auth, debug: 2 });
+```
+
+More usage examples are [here](../examples/Terminal/).
 
 # API
 

--- a/examples/Terminal/emulation.js
+++ b/examples/Terminal/emulation.js
@@ -40,7 +40,7 @@ async function main() {
   }
   // Opening booking in WXYZ
   await TerminalServiceWXYZ.executeCommand(`*${pnr}`);
-  // TickeingTicketing in WXYZ
+  // Ticketing in WXYZ
   await TerminalServiceWXYZ.executeCommand('TKP');
 }
 

--- a/examples/Terminal/emulation.js
+++ b/examples/Terminal/emulation.js
@@ -1,0 +1,41 @@
+const uAPI = require('../../index');
+const auth = require('../../test/testconfig');
+
+const authABCD = {
+  ...auth,
+  emulatePcc: 'ABCD'
+};
+const authWXYZ = {
+  ...auth,
+  emulatePcc: 'WXYZ'
+};
+
+const TerminalServiceABCD = uAPI.createTerminalService({
+  auth: authABCD,
+  debug: 2,
+  production: true,
+});
+
+const TerminalServiceWXYZ = uAPI.createTerminalService({
+  auth: authWXYZ,
+  debug: 2,
+  production: true,
+});
+
+const pnr = 'PNR001';
+
+async function main() {
+  // Opening booking in ABCD
+  await TerminalServiceABCD.executeCommand(`*${pnr}`);
+  // Transfering booking from ABCD to WXYZ
+  const transferResponse = await TerminalServiceABCD.executeCommand('QEB/WXYZ/77');
+  if (!transferResponse.includes('ON QUEUE')) {
+    throw new Error('Booking was not transfered');
+  }
+  // Opening booking in WXYZ
+  await TerminalServiceWXYZ.executeCommand(`*${pnr}`);
+  // TickeingTicketing in WXYZ
+  await TerminalServiceWXYZ.executeCommand('TKP');
+}
+
+main();

--- a/examples/Terminal/emulation.js
+++ b/examples/Terminal/emulation.js
@@ -1,3 +1,9 @@
+/**
+ * This is an example of advnaced emulation, using several PCCs.
+ * In this example you can see a booking transfer from one PCC to another.
+ * You can use this code snippet without any warranties.
+ */
+
 const uAPI = require('../../index');
 const auth = require('../../test/testconfig');
 

--- a/examples/Terminal/ignore.js
+++ b/examples/Terminal/ignore.js
@@ -1,9 +1,10 @@
 const uAPI = require('../../index');
 const testConfig = require('../../test/testconfig');
 
-const config = Object.assign({}, testConfig, {
-  emulatePcc: '7j8j',
-});
+const config = {
+  ...testConfig,
+  emulatePcc: '7J8J',
+};
 
 const TerminalService = uAPI.createTerminalService({
   auth: config,

--- a/examples/Terminal/interactive.js
+++ b/examples/Terminal/interactive.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
-require('babel-register');
 
 const readline = require('readline2');
 const prefix = '>';
 const uAPI = require('../../index');
 const testConfig = require('../../test/testconfig');
 
-const config = Object.assign({}, testConfig);
+const config = {
+  ...testConfig,
+};
 
 const TerminalService = uAPI.createTerminalService({
   auth: config,
@@ -32,7 +33,7 @@ rl.on('line', (line) => {
 
   rl.pause();
   TerminalService
-  .executeCommand(line)
+    .executeCommand(line)
     .then((reply) => {
       process.stdout.write(reply.slice(0, -1));
     })

--- a/examples/Terminal/separate-token.js
+++ b/examples/Terminal/separate-token.js
@@ -2,9 +2,10 @@ const uAPI = require('../../index');
 const testConfig = require('../../test/testconfig');
 
 
-const config = Object.assign({}, testConfig, {
-  emulatePcc: '7j8j',
-});
+const config = {
+  ...testConfig,
+  emulatePcc: '7J8J',
+};
 
 const TerminalService = uAPI.createTerminalService({
   auth: config,

--- a/examples/Terminal/serial.js
+++ b/examples/Terminal/serial.js
@@ -1,9 +1,10 @@
 const uAPI = require('../../index');
 const testConfig = require('../../test/testconfig');
 
-const config = Object.assign({}, testConfig, {
-  emulatePcc: '7j8j',
-});
+const config = {
+  ...testConfig,
+  emulatePcc: '7J8J',
+};
 
 const TerminalService = uAPI.createTerminalService({
   auth: config,

--- a/examples/Terminal/simultaneousError.js
+++ b/examples/Terminal/simultaneousError.js
@@ -1,9 +1,10 @@
 const uAPI = require('../../index');
 const testConfig = require('../../test/testconfig');
 
-const config = Object.assign({}, testConfig, {
-  emulatePcc: '7j8j',
-});
+const config = {
+  ...testConfig,
+  emulatePcc: '7J8J',
+};
 
 const TerminalService = uAPI.createTerminalService({
   auth: config,

--- a/test/testconfig.js
+++ b/test/testconfig.js
@@ -2,5 +2,5 @@ module.exports = {
   username: 'USERNAME',
   password: 'PASSWORD',
   targetBranch: 'BRANCH',
-  pcc: 'PCC',
+  emulatePcc: 'PCC',
 };

--- a/test/testconfig.js
+++ b/test/testconfig.js
@@ -2,5 +2,4 @@ module.exports = {
   username: 'USERNAME',
   password: 'PASSWORD',
   targetBranch: 'BRANCH',
-  emulatePcc: 'PCC',
 };


### PR DESCRIPTION
## PR Purpose
Assigned issue #294.
- Test config fixup
- Readme docs upd
- Terminal docs upd

## PR Notes
I assume the `Pcc` param of `testconfig.js` was declared with the typo for test purposes. The investigation of the fallen CI (Travis) pipeline shows me the problem, tests don't assume the `emulatePcc` parameter for current testing pipelines. Due to the reason, I'm getting rid of the typo and parameter at all. 

## Future changes
In case if `emulatePcc` is necessary to be tested we might need to produce the case of usage by tests.
Also, it might be useful to define pre-hook for tests.