### PR TITLE
Issue 359. Canceling PNR without tickets

### DIFF
--- a/docs/Air.md
+++ b/docs/Air.md
@@ -186,7 +186,7 @@ Ticketing function returns `true` if the process is finished with success or `Er
 
 | Param | Type | Description |
 | --- | --- | --- |
-| comission | `Object{amount|percent}` | If amount is passed than it should be provided with currency. Ex: `{ comission: { amount: 'UAH10' }}`. If percent - it should be string with float number |
+| commission | <code>Object{amount&#124;percent}</code> | If amount is passed than it should be provided with currency. Ex: `{ comission: { amount: 'UAH10' }}`. If percent - it should be string with float number |
 | fop | `Form Of Payment` | See `Form Of Payment` description [below](#fop). |
 | pnr | `String` | 1G PNR. |
 
@@ -386,6 +386,7 @@ Gets pnr information and tickets list from [`importPNR`](#importPNR) and then do
 * if PNR has tickets and `cancelTickets` flag set to `true`, checks tickets
   * if PNR has only tickets with `VOID` or `OPEN` coupons, then tickets are cancelled, then the booking is cancelled
   * if PNR contains tickets with coupons having other statuses, then error is returned
+* if `ignoreTickets` flag set to `true`, all tickets in PNR will be ignored, regardless of their status and `cancelTickets` flag 
 
 **Returns**: `Promise` which is resolved with true
 
@@ -393,5 +394,6 @@ Gets pnr information and tickets list from [`importPNR`](#importPNR) and then do
 | --- | --- | --- |
 | pnr | `String` | PNR |
 | cancelTickets | `Boolean` | Defines if tickets should be cancelled or not |
+| ignoreTickets | `Boolean` | Defines if tickets should be ignored. The default value is `false` |
 
 **See: <a href="../examples/Air/cancelPNR.js">cancelPNR example</a>**

--- a/src/Services/Air/Air.js
+++ b/src/Services/Air/Air.js
@@ -283,54 +283,58 @@ module.exports = (settings) => {
     },
 
     cancelPNR(options) {
+      const ignoreTickets = typeof options.ignoreTickets === 'undefined'
+        ? false // default value
+        : options.ignoreTickets;
+
+      const checkTickets = (tickets) => {
+        return Promise.all(tickets.map(
+          (ticketData) => {
+            // Check for VOID or REFUND
+            const allTicketsVoidOrRefund = ticketData.tickets.every(
+              ticket => ticket.coupons.every(
+                coupon => coupon.status === 'V' || coupon.status === 'R'
+              )
+            );
+            if (allTicketsVoidOrRefund) {
+              return Promise.resolve(true);
+            }
+            // Check for cancelTicket option
+            if (options.cancelTickets !== true) {
+              return Promise.reject(new AirRuntimeError.PNRHasOpenTickets());
+            }
+            // Check for not OPEN/VOID segments
+            const hasNotOpenSegment = ticketData.tickets.some(
+              ticket => ticket.coupons.some(
+                coupon => 'OV'.indexOf(coupon.status) === -1
+              )
+            );
+            if (hasNotOpenSegment) {
+              return Promise.reject(new AirRuntimeError.UnableToCancelTicketStatusNotOpen());
+            }
+            return Promise.all(
+              ticketData.tickets.map(
+                ticket => (
+                  ticket.coupons[0].status !== 'V'
+                    ? service.cancelTicket({
+                      pnr: options.pnr,
+                      ticketNumber: ticket.ticketNumber,
+                    })
+                    : Promise.resolve(true)
+                )
+              )
+            );
+          }
+        ));
+      };
+
       return this.getUniversalRecordByPNR(options)
         .then((ur) => {
           const record = Array.isArray(ur) ? ur[0] : ur;
-
-          return this.getTickets(record)
-            .catch(() => {
-              return Promise.resolve([]);
-            })
-            .then((tickets) => {
-              return Promise.all(tickets.map(
-                (ticketData) => {
-                  // Check for VOID or REFUND
-                  const allTicketsVoidOrRefund = ticketData.tickets.every(
-                    ticket => ticket.coupons.every(
-                      coupon => coupon.status === 'V' || coupon.status === 'R'
-                    )
-                  );
-                  if (allTicketsVoidOrRefund) {
-                    return Promise.resolve(true);
-                  }
-                  // Check for cancelTicket option
-                  if (options.cancelTickets !== true) {
-                    return Promise.reject(new AirRuntimeError.PNRHasOpenTickets());
-                  }
-                  // Check for not OPEN/VOID segments
-                  const hasNotOpenSegment = ticketData.tickets.some(
-                    ticket => ticket.coupons.some(
-                      coupon => 'OV'.indexOf(coupon.status) === -1
-                    )
-                  );
-                  if (hasNotOpenSegment) {
-                    return Promise.reject(new AirRuntimeError.UnableToCancelTicketStatusNotOpen());
-                  }
-                  return Promise.all(
-                    ticketData.tickets.map(
-                      ticket => (
-                        ticket.coupons[0].status !== 'V'
-                          ? service.cancelTicket({
-                            pnr: options.pnr,
-                            ticketNumber: ticket.ticketNumber,
-                          })
-                          : Promise.resolve(true)
-                      )
-                    )
-                  );
-                }
-              ));
-            })
+          return (ignoreTickets
+            ? Promise.resolve([])
+            : this.getTickets(record).then(checkTickets)
+          )
             .then(() => this.getPNR(options))
             .then(booking => service.cancelPNR(booking))
             .catch(

--- a/src/Services/Air/Air.js
+++ b/src/Services/Air/Air.js
@@ -288,6 +288,9 @@ module.exports = (settings) => {
           ur => getBookingFromUr(ur, options.pnr)
             || Promise.reject(new AirRuntimeError.NoPNRFoundInUR(ur))
         )
+        .catch(
+          err => Promise.reject(new AirRuntimeError.FailedToCancelPnr(options, err))
+        )
         .then((record) => {
           return (
             record.tickets.length === 0

--- a/src/Services/Air/Air.js
+++ b/src/Services/Air/Air.js
@@ -288,54 +288,58 @@ module.exports = (settings) => {
           ur => getBookingFromUr(ur, options.pnr)
             || Promise.reject(new AirRuntimeError.NoPNRFoundInUR(ur))
         )
-        .then(record => this.getTickets({
-          reservationLocatorCode: record.uapi_reservation_locator,
-        })
-          .then(
-            tickets => Promise.all(tickets.map(
-              (ticketData) => {
-                // Check for VOID or REFUND
-                const allTicketsVoidOrRefund = ticketData.tickets.every(
-                  ticket => ticket.coupons.every(
-                    coupon => coupon.status === 'V' || coupon.status === 'R'
-                  )
-                );
-                if (allTicketsVoidOrRefund) {
-                  return Promise.resolve(true);
-                }
-                // Check for cancelTicket option
-                if (options.cancelTickets !== true) {
-                  return Promise.reject(new AirRuntimeError.PNRHasOpenTickets());
-                }
-                // Check for not OPEN/VOID segments
-                const hasNotOpenSegment = ticketData.tickets.some(
-                  ticket => ticket.coupons.some(
-                    coupon => 'OV'.indexOf(coupon.status) === -1
-                  )
-                );
-                if (hasNotOpenSegment) {
-                  return Promise.reject(new AirRuntimeError.UnableToCancelTicketStatusNotOpen());
-                }
-                return Promise.all(
-                  ticketData.tickets.map(
-                    ticket => (
-                      ticket.coupons[0].status !== 'V'
-                        ? service.cancelTicket({
-                          pnr: options.pnr,
-                          ticketNumber: ticket.ticketNumber,
-                        })
-                        : Promise.resolve(true)
-                    )
-                  )
-                );
-              }
-            ))
+        .then((record) => {
+          return (
+            record.tickets.length === 0
+              ? Promise.resolve([])
+              : this.getTickets({ reservationLocatorCode: record.uapi_reservation_locator })
           )
-          .then(() => this.getPNR(options))
-          .then(booking => service.cancelPNR(booking))
-          .catch(
-            err => Promise.reject(new AirRuntimeError.FailedToCancelPnr(options, err))
-          ));
+            .then(
+              tickets => Promise.all(tickets.map(
+                (ticketData) => {
+                  // Check for VOID or REFUND
+                  const allTicketsVoidOrRefund = ticketData.tickets.every(
+                    ticket => ticket.coupons.every(
+                      coupon => coupon.status === 'V' || coupon.status === 'R'
+                    )
+                  );
+                  if (allTicketsVoidOrRefund) {
+                    return Promise.resolve(true);
+                  }
+                  // Check for cancelTicket option
+                  if (options.cancelTickets !== true) {
+                    return Promise.reject(new AirRuntimeError.PNRHasOpenTickets());
+                  }
+                  // Check for not OPEN/VOID segments
+                  const hasNotOpenSegment = ticketData.tickets.some(
+                    ticket => ticket.coupons.some(
+                      coupon => 'OV'.indexOf(coupon.status) === -1
+                    )
+                  );
+                  if (hasNotOpenSegment) {
+                    return Promise.reject(new AirRuntimeError.UnableToCancelTicketStatusNotOpen());
+                  }
+                  return Promise.all(
+                    ticketData.tickets.map(
+                      ticket => (
+                        ticket.coupons[0].status !== 'V'
+                          ? service.cancelTicket({
+                            pnr: options.pnr,
+                            ticketNumber: ticket.ticketNumber,
+                          })
+                          : Promise.resolve(true)
+                      )
+                    )
+                  );
+                }
+              ))
+            )
+            .then(() => this.getPNR(options))
+            .then(booking => service.cancelPNR(booking))
+            .catch(
+              err => Promise.reject(new AirRuntimeError.FailedToCancelPnr(options, err))
+            );
+        });
     },
 
     getExchangeInformation(options) {

--- a/src/Services/Air/AirErrors.js
+++ b/src/Services/Air/AirErrors.js
@@ -110,7 +110,7 @@ Object.assign(AirRuntimeError, createErrorsList({
   FailedToCancelPnr: 'Failed to cancel PNR',
   FailedToCancelTicket: 'Failed to cancel ticket',
   UnableToCancelTicketStatusNotOpen: 'Unable to cancel ticket with status not OPEN',
-  PNRHasOpenTickets: 'Selected PNR has tickets. Please use `cancelTickets` option or cancel tickets manually',
+  PNRHasOpenTickets: 'Selected PNR has tickets. Please use `cancelTickets` option or cancel tickets manually, or use `ignoreTickets` option',
   NoReservationToImport: 'No reservation to import',
   UnableToImportPnr: 'Unable to import requested PNR',
   UnableToOpenPNRInTerminal: 'Unable to open requested PNR in Terminal',


### PR DESCRIPTION
Now cancelPNR function won't try to get tickets in advance if getUniversalRecordByPNR returned PNR without any tickets.
There's some bug mentioned in commentary here:
https://github.com/Travelport-Ukraine/uapi-json/blob/abfc3080c078e75c607956c7d05e1a022db7ded9/src/Services/Air/Air.js#L69-L70
If getUniversalRecordByPNR  might return PNR without tickets in some other cases as well, record.tickets.length check should be replaced with something else. 

This check is probably not required and could be removed, because getTickets theoretically should just return an empty list if there was no tickets in requested PNR, but it crashes inside AirErrorHandler on this place for me:
https://github.com/Travelport-Ukraine/uapi-json/blob/abfc3080c078e75c607956c7d05e1a022db7ded9/src/Services/Air/AirParser.js#L306-L307
It tries to call map on undefined, there's no air:AirSegmentError element in my errorInfo:

> {
> 	 "common_v39_0:Code": "3000",
> 	"common_v39_0:Service": "PROVISIONINGSERVICE",
> 	"common_v39_0:Type": "",
> 	"common_v39_0:Description": "The reservation 'AY91L8' has no tickets yet",
> 	"common_v39_0:TransactionId": "D62913960A07643C89F1F5063434A5A3",
> 	"xmlns:common_v39_0": "http://www.travelport.com/schema/common_v39_0"
> }
Probably some non-standard response from Travelport uAPI.


And I fixed the bug I mentioned in https://github.com/Travelport-Ukraine/uapi-json/issues/359#issuecomment-449575377 Unfortunately I'm not very familiar with tests, so I'm leaving them to someone else. Sorry about that.

