### PR TITLE
Air ticket req template - Adds airprice info node to airticketingmodifier

### DIFF
--- a/src/Services/Air/templates/AIR_TICKET_REQUEST.handlebars.js
+++ b/src/Services/Air/templates/AIR_TICKET_REQUEST.handlebars.js
@@ -16,6 +16,9 @@ module.exports = `
       <air:AirPricingInfoRef Key="{{key}}"/>
       {{/refs}}
       <air:AirTicketingModifiers>
+        {{#refs}}
+          <air:AirPricingInfoRef Key="{{key}}"/>
+        {{/refs}}
         {{#if commission}}
         <com:Commission Level="Fare"
           {{#if commission.percent}}


### PR DESCRIPTION
AirPriceReq info node is necessary to book ticket that has child passenger . 
And it has to be included inside AirTicketingModifiers in air ticket request.