### PR TITLE
Condition is always false since types 'boolean' and 'string' have no …

### DIFF
--- a/src/Services/Air/AirParser.js
+++ b/src/Services/Air/AirParser.js
@@ -31,7 +31,7 @@ const searchLowFaresValidate = (obj) => {
 
   rootArrays.forEach((name) => {
     const airName = 'air:' + name + 'List';
-    if (!Object.prototype.toString.call(obj[airName]) === '[object Object]') {
+    if (Object.prototype.toString.call(obj[airName]) !== '[object Object]') {
       throw new AirParsingError.ResponseDataMissing({ missing: airName });
     }
   });


### PR DESCRIPTION
changed 
if (!Object.prototype.toString.call(obj[airName]) === '[object Object]') 
to 
if (Object.prototype.toString.call(obj[airName]) !== '[object Object]')

this PR might result AirParsingError.ResponseDataMissing to someone using SolutionResult in LFS