### PR TITLE
handle-travelport-server-error

### DIFF
--- a/src/Services/Air/Air.js
+++ b/src/Services/Air/Air.js
@@ -54,8 +54,10 @@ module.exports = (settings) => {
           ActionStatusType: 'TAU',
         }, data, options);
         return service.createReservation(bookingParams).catch((err) => {
-          if (err instanceof AirRuntimeError.SegmentBookingFailed
-              || err instanceof AirRuntimeError.NoValidFare) {
+          if (
+            err.data.faultcode !== "Server.Business" 
+            && (err instanceof AirRuntimeError.SegmentBookingFaile || err instanceof AirRuntimeError.NoValidFare)
+          ) {
             if (options.allowWaitlist) { // will not have a UR if waitlisting restricted
               const code = err.data['universal:UniversalRecord'].LocatorCode;
               return service.cancelUR({


### PR DESCRIPTION
If travelport is having a `General air service Error.` it returns an error without err.data['universal:UniversalRecord']

`{ 
     faultcode: 'Server.Business',
     faultstring: 'General air service Error.',
     detail: { 'air:AvailabilityErrorInfo': [Object] } }
 }`