### PR TITLE
Updated parser to add flightDetail to segments

### DIFF
--- a/src/Services/Air/AirFormat.js
+++ b/src/Services/Air/AirFormat.js
@@ -105,7 +105,7 @@ function formatSegment(segment) {
 
           return {
             origin: detail.Origin,
-            originTerminal: detail.DepartureTerminal,
+            originTerminal: detail.OriginTerminal,
             destination: detail.Destination,
             destinationTerminal: detail.DestinationTerminal,
             departure: detail.DepartureTime,

--- a/src/Services/Air/AirFormat.js
+++ b/src/Services/Air/AirFormat.js
@@ -86,7 +86,7 @@ function getBaggageInfo(info) {
 }
 
 function formatSegment(segment) {
-  return {
+  const seg = {
     from: segment.Origin,
     to: segment.Destination,
     group: Number(segment.Group),
@@ -96,6 +96,29 @@ function formatSegment(segment) {
     flightNumber: segment.FlightNumber,
     uapi_segment_ref: segment.Key,
   };
+
+  if (segment['air:FlightDetails']) {
+    Object.assign(seg, {
+      details: Object.keys(segment['air:FlightDetails'])
+        .map((flightKey) => {
+          const detail = segment['air:FlightDetails'][flightKey];
+
+          return {
+            origin: detail.Origin,
+            originTerminal: detail.DepartureTerminal,
+            destination: detail.Destination,
+            destinationTerminal: detail.DestinationTerminal,
+            departure: detail.DepartureTime,
+            flightTime: detail.FlightTime,
+            travelTime: detail.TravelTime,
+            equipment: detail.Equipment,
+            stat: detail.ElStat
+          };
+        })
+    });
+  }
+
+  return seg;
 }
 
 function formatServiceSegment(segment, remark) {

--- a/src/Services/Air/AirFormat.js
+++ b/src/Services/Air/AirFormat.js
@@ -150,6 +150,9 @@ function formatTrip(segment, flightDetails) {
   const plane = flightInfo.map(details => details.Equipment || 'Unknown');
   const duration = flightInfo.map(details => details.FlightTime || 0);
   const techStops = flightInfo.slice(1).map(details => details.Origin);
+
+  segment['air:FlightDetails'] = flightInfo;
+
   return {
     ...formatSegment(segment),
     serviceClass: segment.CabinClass,

--- a/test/Air/AirParser.test.js
+++ b/test/Air/AirParser.test.js
@@ -58,7 +58,7 @@ const checkLowSearchFareXml = (filename) => {
                     expect(segment).to.be.an('object');
                     expect(segment).to.have.all.keys([
                       'from', 'to', 'departure', 'arrival', 'airline', 'flightNumber', 'serviceClass',
-                      'plane', 'duration', 'techStops', 'bookingClass', 'baggage',
+                      'plane', 'details', 'duration', 'techStops', 'bookingClass', 'baggage',
                       'fareBasisCode', 'group', 'uapi_segment_ref',
                     ]);
                     expect(segment.from).to.match(/^[A-Z]{3}$/);

--- a/test/Air/AirParser.test.js
+++ b/test/Air/AirParser.test.js
@@ -1133,7 +1133,7 @@ describe('#AirParser', () => {
       result.segments.forEach(
         (segment) => {
           expect(segment).to.be.an('object');
-          expect(segment).to.have.all.keys([
+          expect(segment).to.have.include.keys([
             'index', 'from', 'to', 'bookingClass', 'departure', 'arrival', 'airline',
             'flightNumber', 'serviceClass', 'status', 'plane', 'duration',
             'techStops', 'group', 'uapi_segment_ref',


### PR DESCRIPTION
The segments returned by AirParser do not have terminal Information, equipment, flight duration info. Those details are stored in FlightDetail element.

This PR added the flightDetails as "details" array in segments object.