### PR TITLE
Single exit/beforeExit handler for all terminals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uapi-json",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uapi-json",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Travelport Universal API",
   "main": "src/",
   "files": [

--- a/src/Services/Terminal/Terminal.js
+++ b/src/Services/Terminal/Terminal.js
@@ -11,6 +11,54 @@ const TERMINAL_STATE_CLOSED = 'TERMINAL_STATE_CLOSED';
 const TERMINAL_STATE_ERROR = 'TERMINAL_STATE_ERROR';
 
 const screenFunctions = screenLib({ cursor: '><' });
+const autoCloseTerminals = [];
+
+// Adding event handler on beforeExit and exit process events to process open terminals
+process.on('beforeExit', () => {
+  autoCloseTerminals.forEach(({ state, terminal, log }) => {
+    switch (state.terminalState) {
+      case TERMINAL_STATE_BUSY:
+      case TERMINAL_STATE_READY:
+      case TERMINAL_STATE_ERROR:
+        if (state.terminalState === TERMINAL_STATE_BUSY) {
+          log('UAPI-JSON WARNING: Process exited before completing TerminalService request');
+        }
+        if (state.sessionToken !== null) {
+          log('UAPI-JSON WARNING: Process left TerminalService session open');
+          log('UAPI-JSON WARNING: Session closing');
+          terminal.closeSession().then(
+            () => log('UAPI-JSON WARNING: Session closed')
+          ).catch(
+            () => {
+              throw new TerminalRuntimeError.ErrorClosingSession();
+            }
+          );
+        }
+        break;
+      default:
+        break;
+    }
+  });
+});
+/* istanbul ignore next */
+process.on('exit', () => {
+  autoCloseTerminals.forEach(({ state, log }) => {
+    switch (state.terminalState) {
+      case TERMINAL_STATE_BUSY:
+      case TERMINAL_STATE_READY:
+      case TERMINAL_STATE_ERROR:
+        if (state.terminalState === TERMINAL_STATE_BUSY) {
+          log('UAPI-JSON WARNING: Process exited before completing TerminalService request');
+        }
+        if (state.sessionToken !== null) {
+          log('UAPI-JSON WARNING: Process left TerminalService session open');
+        }
+        break;
+      default:
+        break;
+    }
+  });
+});
 
 module.exports = function (settings) {
   const service = terminalService(validateServiceSettings(settings));
@@ -142,48 +190,7 @@ module.exports = function (settings) {
   };
 
   if (autoClose) {
-    // Adding event handler on beforeExit and exit process events
-    process.on('beforeExit', () => {
-      switch (state.terminalState) {
-        case TERMINAL_STATE_BUSY:
-        case TERMINAL_STATE_READY:
-        case TERMINAL_STATE_ERROR:
-          if (state.terminalState === TERMINAL_STATE_BUSY) {
-            log('UAPI-JSON WARNING: Process exited before completing TerminalService request');
-          }
-          if (state.sessionToken !== null) {
-            log('UAPI-JSON WARNING: Process left TerminalService session open');
-            log('UAPI-JSON WARNING: Session closing');
-            terminal.closeSession().then(
-              () => log('UAPI-JSON WARNING: Session closed')
-            ).catch(
-              () => {
-                throw new TerminalRuntimeError.ErrorClosingSession();
-              }
-            );
-          }
-          break;
-        default:
-          break;
-      }
-    });
-    /* istanbul ignore next */
-    process.on('exit', () => {
-      switch (state.terminalState) {
-        case TERMINAL_STATE_BUSY:
-        case TERMINAL_STATE_READY:
-        case TERMINAL_STATE_ERROR:
-          if (state.terminalState === TERMINAL_STATE_BUSY) {
-            log('UAPI-JSON WARNING: Process exited before completing TerminalService request');
-          }
-          if (state.sessionToken !== null) {
-            log('UAPI-JSON WARNING: Process left TerminalService session open');
-          }
-          break;
-        default:
-          break;
-      }
-    });
+    autoCloseTerminals.push({ state, terminal, log });
   }
 
   return terminal;

--- a/test/Terminal/Terminal.test.js
+++ b/test/Terminal/Terminal.test.js
@@ -211,6 +211,38 @@ describe('#Terminal', function terminalTest() {
           }, 100);
         });
     });
+    it.only('should autoclose more than one terminal', (done) => {
+      // Resetting spies
+      closeSessionError.resetHistory();
+
+      const uAPITerminal1 = terminalCloseSessionError({
+        auth: config,
+        debug: 1,
+      });
+      const uAPITerminal2 = terminalCloseSessionError({
+        auth: config,
+        debug: 1,
+      });
+
+      Promise.all([
+        uAPITerminal1.executeCommand('I')
+          .then(() => {
+            expect(closeSession.callCount).to.equal(0);
+          }),
+        uAPITerminal2.executeCommand('I')
+          .then(() => {
+            expect(closeSession.callCount).to.equal(0);
+          }),
+      ]).then(() => {
+        process.emit('beforeExit');
+        setTimeout(() => {
+          expect(closeSessionError).to.have.callCount(2);
+          expect(DumbErrorClosingSession).to.have.callCount(2);
+          expect(console.log).to.have.callCount(8);
+          done();
+        }, 100);
+      });  
+    });
     it('should throw an error for terminal with READY state', (done) => {
       // Resetting spies
       closeSession.resetHistory();

--- a/test/Terminal/Terminal.test.js
+++ b/test/Terminal/Terminal.test.js
@@ -241,7 +241,7 @@ describe('#Terminal', function terminalTest() {
           expect(console.log).to.have.callCount(8);
           done();
         }, 100);
-      });  
+      });
     });
     it('should throw an error for terminal with READY state', (done) => {
       // Resetting spies

--- a/test/Terminal/Terminal.test.js
+++ b/test/Terminal/Terminal.test.js
@@ -237,8 +237,8 @@ describe('#Terminal', function terminalTest() {
         process.emit('beforeExit');
         setTimeout(() => {
           expect(closeSessionError).to.have.callCount(1);
-          expect(DumbErrorClosingSession).to.have.callCount(1);
-          expect(console.log).to.have.callCount(9);
+          expect(DumbErrorClosingSession).to.have.callCount(3);
+          expect(console.log).to.have.callCount(12);
           done();
         }, 100);
       });

--- a/test/Terminal/Terminal.test.js
+++ b/test/Terminal/Terminal.test.js
@@ -237,7 +237,7 @@ describe('#Terminal', function terminalTest() {
         process.emit('beforeExit');
         setTimeout(() => {
           expect(closeSessionError).to.have.callCount(1);
-          expect(DumbErrorClosingSession).to.have.callCount(3);
+          expect(DumbErrorClosingSession).to.have.callCount(2);
           expect(console.log).to.have.callCount(12);
           done();
         }, 100);

--- a/test/Terminal/Terminal.test.js
+++ b/test/Terminal/Terminal.test.js
@@ -211,7 +211,7 @@ describe('#Terminal', function terminalTest() {
           }, 100);
         });
     });
-    it.only('should autoclose more than one terminal', (done) => {
+    it('should autoclose more than one terminal', (done) => {
       // Resetting spies
       closeSessionError.resetHistory();
 
@@ -219,7 +219,7 @@ describe('#Terminal', function terminalTest() {
         auth: config,
         debug: 1,
       });
-      const uAPITerminal2 = terminalCloseSessionError({
+      const uAPITerminal2 = terminalOk({
         auth: config,
         debug: 1,
       });
@@ -236,9 +236,9 @@ describe('#Terminal', function terminalTest() {
       ]).then(() => {
         process.emit('beforeExit');
         setTimeout(() => {
-          expect(closeSessionError).to.have.callCount(2);
-          expect(DumbErrorClosingSession).to.have.callCount(2);
-          expect(console.log).to.have.callCount(8);
+          expect(closeSessionError).to.have.callCount(1);
+          expect(DumbErrorClosingSession).to.have.callCount(1);
+          expect(console.log).to.have.callCount(9);
           done();
         }, 100);
       });


### PR DESCRIPTION
When multiple terminals are created (and not closed) node js could throw unhandled exception.
Now all terminals will use the single handler.