### PR TITLE
Better access checks for AirService

### DIFF
--- a/docs/Air.md
+++ b/docs/Air.md
@@ -358,13 +358,14 @@ Request for the ticket information.
 > May require Terminal access enabled in uAPI. See [TerminalService](Terminal.md)
 
 Request for the ticket information for all tickets in PNR.
+First gets information about PNR, which allows to tell if credentials are allowed to list tickets for the PNR. Also automatically fetched UR locator, so PNR only should be provided.
 
 **Returns**: `Promise`
 **See**: [Ticket Information](https://support.travelport.com/webhelp/uapi/uAPI.htm#Air/Air_Ticketing/Displaying_Ticket_Information.htm)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| reservationLocatorCode | `String` | uAPI reservation code. |
+| pnr | `String` | 1G PNR. |
 
 **See: <a href="../examples/Air/getTickets.js">getTickets example</a>**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uapi-json",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uapi-json",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Travelport Universal API",
   "main": "src/",
   "files": [

--- a/src/Services/Air/Air.js
+++ b/src/Services/Air/Air.js
@@ -241,10 +241,16 @@ module.exports = (settings) => {
         });
     },
 
-    getTickets(options) {
-      return service.getTickets(options).catch(
-        err => Promise.reject(new AirRuntimeError.UnableToRetrieveTickets(options, err))
-      );
+    async getTickets(options) {
+      const { pnr } = options;
+      const ur = await this.getUniversalRecordByPNR({ pnr });
+      const urData = Array.isArray(ur) ? ur[0] : ur;
+      const { uapi_reservation_locator: reservationLocatorCode } = urData;
+      try {
+        return await service.getTickets({ reservationLocatorCode });
+      } catch (err) {
+        throw new AirRuntimeError.UnableToRetrieveTickets(options, err);
+      }
     },
 
     getBookingByTicketNumber(options) {

--- a/src/Services/Air/AirParser.js
+++ b/src/Services/Air/AirParser.js
@@ -436,12 +436,15 @@ const AirErrorHandler = function (rsp) {
   } catch (err) {
     throw new RequestRuntimeError.UnhandledError(null, new AirRuntimeError(rsp));
   }
+  const pcc = utils.getErrorPcc(rsp.faultstring);
   switch (code) {
     case '345':
-      throw new AirRuntimeError.NoAgreement({
-        pcc: utils.getErrorPcc(rsp.faultstring),
-      });
     case '1512':
+      if (pcc !== null) {
+        throw new AirRuntimeError.NoAgreement({
+          pcc: utils.getErrorPcc(rsp.faultstring),
+        });
+      }
       throw new AirRuntimeError.UnableToRetrieve(rsp);
     case '4454':
       throw new AirRuntimeError.NoResidualValue(rsp);

--- a/test/Air/Air.test.js
+++ b/test/Air/Air.test.js
@@ -1064,7 +1064,7 @@ describe('#AirService', () => {
   });
 
   describe('getTickets', () => {
-    it('should throw an error when some function fails', (done) => {
+    it('should throw an error when some function fails', async () => {
       const AirService = () => ({
         getUniversalRecordByPNR: () => Promise.resolve({ uapi_reservation_locator: 'RLC001' }),
         getTickets: () => Promise.reject(new Error('Some error')),
@@ -1074,13 +1074,13 @@ describe('#AirService', () => {
       });
       const service = createAirService({ auth });
 
-      service.getTickets({ uapi_reservation_locator: 'RLC001' })
-        .then(() => done(new Error('Error has not occured')))
-        .catch((err) => {
-          expect(err).to.be.an.instanceof(AirRuntimeError.UnableToRetrieveTickets);
-          expect(err.causedBy).to.be.an.instanceof(Error);
-          done();
-        });
+      try {
+        await service.getTickets({ uapi_reservation_locator: 'RLC001' });
+        throw new Error('No error thrown!');
+      } catch (err) {
+        expect(err).to.be.an.instanceof(AirRuntimeError.UnableToRetrieveTickets);
+        expect(err.causedBy).to.be.an.instanceof(Error);
+      }
     });
     it('should work with right responses', (done) => {
       const importBookingVoidResponse = JSON.parse(
@@ -1371,7 +1371,7 @@ describe('#AirService', () => {
           pnr: 'PNR001',
         })
         .then(() => {
-          expect(getUniversalRecordByPNR).to.have.callCount(2);
+          expect(getUniversalRecordByPNR).to.have.callCount(3);
           expect(getTicket).to.have.callCount(0);
           expect(cancelBooking).to.have.callCount(1);
         });
@@ -1405,7 +1405,7 @@ describe('#AirService', () => {
           pnr: 'PNR001',
         })
         .then(() => {
-          expect(getUniversalRecordByPNR).to.have.callCount(2);
+          expect(getUniversalRecordByPNR).to.have.callCount(3);
           expect(getTickets).to.have.callCount(1);
           expect(cancelBooking).to.have.callCount(1);
         });
@@ -1454,7 +1454,7 @@ describe('#AirService', () => {
         .catch((err) => {
           expect(err).to.be.an.instanceof(AirRuntimeError.FailedToCancelPnr);
           expect(err.causedBy).to.be.an.instanceof(AirRuntimeError.PNRHasOpenTickets);
-          expect(getUniversalRecordByPNR).to.have.callCount(1);
+          expect(getUniversalRecordByPNR).to.have.callCount(2);
           expect(getTickets).to.have.callCount(1);
           expect(cancelBooking).to.have.callCount(0);
         });
@@ -1493,7 +1493,7 @@ describe('#AirService', () => {
           pnr: 'PNR001',
         })
         .then(() => {
-          expect(getUniversalRecordByPNR).to.have.callCount(2);
+          expect(getUniversalRecordByPNR).to.have.callCount(3);
           expect(getTickets).to.have.callCount(1);
           expect(cancelBooking).to.have.callCount(1);
         });
@@ -1541,7 +1541,7 @@ describe('#AirService', () => {
           pnr: 'PNR001',
         })
         .then(() => {
-          expect(getUniversalRecordByPNR).to.have.callCount(2);
+          expect(getUniversalRecordByPNR).to.have.callCount(3);
           expect(getTickets).to.have.callCount(1);
           expect(cancelBooking).to.have.callCount(1);
         });
@@ -1596,7 +1596,7 @@ describe('#AirService', () => {
           cancelTickets: true,
         })
         .then(() => {
-          expect(getUniversalRecordByPNR).to.have.callCount(2);
+          expect(getUniversalRecordByPNR).to.have.callCount(3);
           expect(getTickets).to.have.callCount(1);
           expect(cancelBooking).to.have.callCount(1);
           expect(cancelTicket).to.have.callCount(1);
@@ -1647,7 +1647,7 @@ describe('#AirService', () => {
           expect(err.causedBy).to.be.an.instanceof(
             AirRuntimeError.UnableToCancelTicketStatusNotOpen
           );
-          expect(getUniversalRecordByPNR).to.have.callCount(1);
+          expect(getUniversalRecordByPNR).to.have.callCount(2);
           expect(getTickets).to.have.callCount(1);
           expect(cancelBooking).to.have.callCount(0);
         });
@@ -1696,7 +1696,7 @@ describe('#AirService', () => {
         })
         .then((result) => {
           expect(result).to.equal(true);
-          expect(getUniversalRecordByPNR).to.have.callCount(2);
+          expect(getUniversalRecordByPNR).to.have.callCount(3);
           expect(getTickets).to.have.callCount(1);
           expect(cancelTicket).to.have.callCount(1);
           expect(cancelBooking).to.have.callCount(1);
@@ -1741,9 +1741,9 @@ describe('#AirService', () => {
         () => Promise.resolve(getURbyPNRSampleTicketed)
       );
 
-      const exchange = sinon.spy(({ exchangeToken, uapi_reservation_locator }) => {
+      const exchange = sinon.spy(({ exchangeToken, uapi_reservation_locator: locator }) => {
         expect(exchangeToken).to.be.equal('token');
-        expect(uapi_reservation_locator).to.be.equal('ABCDEF');
+        expect(locator).to.be.equal('ABCDEF');
       });
 
       const airService = () => ({

--- a/test/Air/AirParser.test.js
+++ b/test/Air/AirParser.test.js
@@ -2206,40 +2206,28 @@ describe('#AirParser', () => {
   });
 
   describe('AIR_ERROR', () => {
-    it('should correctly handle archived booking', () => {
-      const uParser = new Parser('air:LowFareSearchRsp', 'v47_0', {});
-      const parseFunction = airParser.AIR_ERRORS;
-      const xml = fs.readFileSync(`${xmlFolder}/UnableToRetrieve.xml`).toString();
-      return uParser.parse(xml)
-        .then(
-          (json) => {
-            const errData = uParser.mergeLeafRecursive(json['SOAP:Fault'][0]); // parse error data
-            return parseFunction.call(uParser, errData);
-          }
-        )
-        .catch(
-          (err) => {
-            expect(err).to.be.an.instanceof(AirRuntimeError.UnableToRetrieve);
-          }
+    it('should correctly handle archived booking', async () => {
+      try {
+        await getParseResponse(
+          'air:LowFareSearchRsp', 'UnableToRetrieve.xml',
+          airParser.AIR_LOW_FARE_SEARCH_REQUEST, airParser.AIR_ERRORS
         );
+        throw new Error('Error not thrown');
+      } catch (err) {
+        expect(err).to.be.an.instanceof(AirRuntimeError.UnableToRetrieve);
+      }
     });
-    it('should correctly handle error of agreement 2', () => {
-      const uParser = new Parser('air:LowFareSearchRsp', 'v47_0', {});
-      const parseFunction = airParser.AIR_ERRORS;
-      const xml = fs.readFileSync(`${xmlFolder}/NoAgreementError.xml`).toString();
-      return uParser.parse(xml)
-        .then(
-          (json) => {
-            const errData = uParser.mergeLeafRecursive(json['SOAP:Fault'][0]); // parse error data
-            return parseFunction.call(uParser, errData);
-          }
-        )
-        .catch(
-          (err) => {
-            expect(err).to.be.an.instanceof(AirRuntimeError.NoAgreement);
-            expect(err.data.pcc).to.be.equal('7J8J');
-          }
+    it('should correctly handle error of agreement 2', async () => {
+      try {
+        await getParseResponse(
+          'air:LowFareSearchRsp', 'NoAgreementError.xml',
+          airParser.AIR_LOW_FARE_SEARCH_REQUEST, airParser.AIR_ERRORS
         );
+        throw new Error('Error not thrown');
+      } catch (err) {
+        expect(err).to.be.an.instanceof(AirRuntimeError.NoAgreement);
+        expect(err.data.pcc).to.be.equal('7J8J');
+      }
     });
   });
 });

--- a/test/Air/AirParser.test.js
+++ b/test/Air/AirParser.test.js
@@ -2134,74 +2134,50 @@ describe('#AirParser', () => {
         });
     });
 
-    it('should parse response with A and C availability', () => {
-      const uParser = new Parser('air:AvailabilitySearchRsp', 'v47_0', {
-        cabins: ['Economy'],
-      });
-
-      const parseFunction = airParser.AIR_AVAILABILITY;
-      const xml = fs.readFileSync(`${xmlFolder}/AirAvailabilityRsp3.xml`).toString();
-      return uParser
-        .parse(xml)
-        .then(json => parseFunction.call(uParser, json))
-        .then((result) => {
-          testAvailability(result);
-        });
+    it('should parse response with A and C availability', async () => {
+      const res = await getParseResponse(
+        'air:AvailabilitySearchRsp', 'AirAvailabilityRsp3.xml',
+        airParser.AIR_AVAILABILITY, airParser.AIR_ERRORS,
+        { cabins: ['Economy'] }
+      );
+      testAvailability(res);
     });
 
-    it('should parse response without connections', () => {
-      const uParser = new Parser('air:AvailabilitySearchRsp', 'v47_0', {});
-
-      const parseFunction = airParser.AIR_AVAILABILITY;
-      const xml = fs.readFileSync(`${xmlFolder}/AirAvailabilityRsp2.xml`).toString();
-      return uParser
-        .parse(xml)
-        .then(json => parseFunction.call(uParser, json))
-        .then((result) => {
-          testAvailability(result);
-          expect(result.nextResultReference).to.be.null;
-        });
+    it('should parse response without connections', async () => {
+      const res = await getParseResponse(
+        'air:AvailabilitySearchRsp', 'AirAvailabilityRsp2.xml',
+        airParser.AIR_AVAILABILITY
+      );
+      testAvailability(res);
+      expect(res.nextResultReference).to.be.null;
     });
 
-    it('should parse response with single connection', () => {
-      const uParser = new Parser('air:AvailabilitySearchRsp', 'v47_0', {});
-
-      const parseFunction = airParser.AIR_AVAILABILITY;
-      const xml = fs.readFileSync(`${xmlFolder}/AirAvailabilityRsp-single-connection.xml`).toString();
-      return uParser
-        .parse(xml)
-        .then(json => parseFunction.call(uParser, json))
-        .then((result) => {
-          testAvailability(result);
-          expect(result.nextResultReference).to.be.null;
-        });
+    it('should parse response with single connection', async () => {
+      const res = await getParseResponse(
+        'air:AvailabilitySearchRsp', 'AirAvailabilityRsp-single-connection.xml',
+        airParser.AIR_AVAILABILITY
+      );
+      testAvailability(res);
+      expect(res.nextResultReference).to.be.null;
     });
 
-    it('should parse response without 1G avail info', () => {
-      const uParser = new Parser('air:AvailabilitySearchRsp', 'v47_0', {});
-
-      const parseFunction = airParser.AIR_AVAILABILITY;
-      const xml = fs.readFileSync(`${xmlFolder}/AirAvailabilityRsp4-NO1G.xml`).toString();
-      return uParser
-        .parse(xml)
-        .then(json => parseFunction.call(uParser, json))
-        .then((result) => {
-          expect(result.legs.length).to.be.equal(0);
-        });
+    it('should parse response without 1G avail info', async () => {
+      const res = await getParseResponse(
+        'air:AvailabilitySearchRsp', 'AirAvailabilityRsp4-NO1G.xml',
+        airParser.AIR_AVAILABILITY
+      );
+      testAvailability(res);
+      expect(res.legs.length).to.be.equal(0);
     });
 
-    it('should parse response without 1G avail info', () => {
-      const uParser = new Parser('air:AvailabilitySearchRsp', 'v47_0', {});
-
-      const parseFunction = airParser.AIR_AVAILABILITY;
-      const xml = fs.readFileSync(`${xmlFolder}/AirAvailabilityRsp5.xml`).toString();
-      return uParser
-        .parse(xml)
-        .then(json => parseFunction.call(uParser, json))
-        .then((result) => {
-          expect(result.legs).to.have.length(7);
-          expect(result.legs[0]).to.have.length(2);
-        });
+    it('should parse response without 1G avail info', async () => {
+      const res = await getParseResponse(
+        'air:AvailabilitySearchRsp', 'AirAvailabilityRsp5.xml',
+        airParser.AIR_AVAILABILITY
+      );
+      testAvailability(res);
+      expect(res.legs).to.have.length(7);
+      expect(res.legs[0]).to.have.length(2);
     });
   });
 

--- a/test/Air/AirParser.test.js
+++ b/test/Air/AirParser.test.js
@@ -2116,22 +2116,14 @@ describe('#AirParser', () => {
           });
         });
       });
-
-      return true;
     }
-    it('should parse simple response', () => {
-      const uParser = new Parser('air:AvailabilitySearchRsp', 'v47_0', {
-        cabins: ['Economy'],
-      });
-
-      const parseFunction = airParser.AIR_AVAILABILITY;
-      const xml = fs.readFileSync(`${xmlFolder}/AirAvailabilityRsp.xml`).toString();
-      return uParser
-        .parse(xml)
-        .then(json => parseFunction.call(uParser, json))
-        .then((result) => {
-          testAvailability(result);
-        });
+    it('should parse simple response', async () => {
+      const res = await getParseResponse(
+        'air:AvailabilitySearchRsp', 'AirAvailabilityRsp.xml',
+        airParser.AIR_AVAILABILITY, airParser.AIR_ERRORS,
+        { cabins: ['Economy'] }
+      );
+      testAvailability(res);
     });
 
     it('should parse response with A and C availability', async () => {

--- a/test/Air/AirParser.test.js
+++ b/test/Air/AirParser.test.js
@@ -222,7 +222,7 @@ describe('#AirParser', () => {
       const res = parseFunction.call(uParser, rsp);
       expect(res).to.be.a('array').and.to.have.lengthOf(1);
     });
-    it('should correctly handle error of agreement', async () => {
+    it('should correctly handle error of agreement 1', async () => {
       const uParser = new Parser('air:AirRetrieveDocumentRsp', 'v47_0', {});
       const errorHandler = airParser.AIR_GET_TICKETS_ERROR_HANDLER;
       const xml = fs.readFileSync(`${xmlFolder}/NoAgreementError.xml`).toString();
@@ -2210,7 +2210,7 @@ describe('#AirParser', () => {
           }
         );
     });
-    it('should correctly handle error of agreement', () => {
+    it('should correctly handle error of agreement 2', () => {
       const uParser = new Parser('air:LowFareSearchRsp', 'v47_0', {});
       const parseFunction = airParser.AIR_ERRORS;
       const xml = fs.readFileSync(`${xmlFolder}/NoAgreementError.xml`).toString();

--- a/test/Air/AirParser.test.js
+++ b/test/Air/AirParser.test.js
@@ -138,19 +138,43 @@ const checkLowSearchFareXml = (filename) => {
   });
 };
 
+function shouldParseWithError(parser, data, error) {
+  const parse = () => parser.call({ uapi_version: 'v47_0' }, data);
+  expect(parse).to.throw(error);
+}
+
+async function getParseResponse(root, file, parser = null, errorHandler = null, data = {}) {
+  const uParser = new Parser(root, 'v47_0', data);
+  const xml = fs.readFileSync(`${xmlFolder}/${file}`).toString();
+  const rsp = await uParser.parse(xml);
+
+  if (!Object.keys(rsp).includes('SOAP:Fault')) {
+    return parser && parser.call(uParser, rsp);
+  }
+
+  const errRsp = errorHandler.call(uParser, uParser.mergeLeafRecursive(rsp['SOAP:Fault'][0]));
+  return parser && parser.call(uParser, errRsp);
+}
+
 describe('#AirParser', () => {
   describe('AIR_CANCEL_TICKET', () => {
     it('should return error when no VoidResultInfo available', () => {
-      const check = () => airParser.AIR_CANCEL_TICKET({});
-      expect(check).to.throw(AirRuntimeError.TicketCancelResultUnknown);
+      shouldParseWithError(
+        airParser.AIR_CANCEL_TICKET,
+        {},
+        AirRuntimeError.TicketCancelResultUnknown
+      );
     });
     it('should return error when no VoidResultInfo Result type is not Success', () => {
-      const check = () => airParser.AIR_CANCEL_TICKET({
-        'air:VoidResultInfo': {
-          ResultType: 'Fail',
+      shouldParseWithError(
+        airParser.AIR_CANCEL_TICKET,
+        {
+          'air:VoidResultInfo': {
+            ResultType: 'Fail',
+          },
         },
-      });
-      expect(check).to.throw(AirRuntimeError.TicketCancelResultUnknown);
+        AirRuntimeError.TicketCancelResultUnknown
+      );
     });
     it('should return true if everything is ok', () => {
       const check = () => airParser.AIR_CANCEL_TICKET({
@@ -163,22 +187,23 @@ describe('#AirParser', () => {
   });
   describe('AIR_CANCEL_PNR', () => {
     it('should return error when no messages available', () => {
-      const check = () => airParser.AIR_CANCEL_PNR.call({
-        uapi_version: 'v47_0',
-      }, {});
-      expect(check).to.throw(AirParsingError.CancelResponseNotFound);
+      shouldParseWithError(
+        airParser.AIR_CANCEL_PNR,
+        {},
+        AirParsingError.CancelResponseNotFound
+      );
     });
     it('should return error when message do not contain Success message', () => {
-      const check = () => airParser.AIR_CANCEL_PNR.call({
-        uapi_version: 'v47_0',
-      }, {
-        'common_v47_0:ResponseMessage': [{
-          _: 'Some message',
-        }, {
-          _: 'Another message',
-        }],
-      });
-      expect(check).to.throw(AirParsingError.CancelResponseNotFound);
+      shouldParseWithError(
+        airParser.AIR_CANCEL_PNR,
+        {
+          'common_v47_0:ResponseMessage': [
+            { _: 'Some message' },
+            { _: 'Another message' },
+          ],
+        },
+        AirParsingError.CancelResponseNotFound
+      );
     });
     it('should return true if everything is ok', () => {
       const check = () => airParser.AIR_CANCEL_PNR.call({
@@ -194,57 +219,45 @@ describe('#AirParser', () => {
 
   describe('getTickets', () => {
     it('should return empty array if UR have no tickets', async () => {
-      const uParser = new Parser('air:AirRetrieveDocumentRsp', 'v47_0', {});
-      const parseFunction = airParser.AIR_GET_TICKETS;
-      const errorHandler = airParser.AIR_GET_TICKETS_ERROR_HANDLER;
-      const xml = fs.readFileSync(`${xmlFolder}/AirGetTickets-error-no-tickets.xml`).toString();
-
-      const rsp = await uParser.parse(xml);
-      const errRsp = errorHandler.call(uParser, uParser.mergeLeafRecursive(rsp['SOAP:Fault'][0]));
-      const res = parseFunction.call(uParser, errRsp);
+      const res = await getParseResponse(
+        'air:AirRetrieveDocumentRsp', 'AirGetTickets-error-no-tickets.xml',
+        airParser.AIR_GET_TICKETS, airParser.AIR_GET_TICKETS_ERROR_HANDLER
+      );
       expect(res).to.be.a('array').that.is.empty;
     });
     it('should return array if UR have tickets', async () => {
-      const uParser = new Parser('air:AirRetrieveDocumentRsp', 'v47_0', {});
-      const parseFunction = airParser.AIR_GET_TICKETS;
-      const xml = fs.readFileSync(`${xmlFolder}/AirGetTickets-several-tickets.xml`).toString();
-
-      const rsp = await uParser.parse(xml);
-      const res = parseFunction.call(uParser, rsp);
+      const res = await getParseResponse(
+        'air:AirRetrieveDocumentRsp', 'AirGetTickets-several-tickets.xml',
+        airParser.AIR_GET_TICKETS
+      );
       expect(res).to.be.a('array').and.to.have.lengthOf(2);
     });
     it('should return array if UR has one ticket', async () => {
-      const uParser = new Parser('air:AirRetrieveDocumentRsp', 'v47_0', {});
-      const parseFunction = airParser.AIR_GET_TICKETS;
-      const xml = fs.readFileSync(`${xmlFolder}/AirGetTickets-one-ticket.xml`).toString();
-
-      const rsp = await uParser.parse(xml);
-      const res = parseFunction.call(uParser, rsp);
+      const res = await getParseResponse(
+        'air:AirRetrieveDocumentRsp', 'AirGetTickets-one-ticket.xml',
+        airParser.AIR_GET_TICKETS
+      );
       expect(res).to.be.a('array').and.to.have.lengthOf(1);
     });
     it('should correctly handle error of agreement 1', async () => {
-      const uParser = new Parser('air:AirRetrieveDocumentRsp', 'v47_0', {});
-      const errorHandler = airParser.AIR_GET_TICKETS_ERROR_HANDLER;
-      const xml = fs.readFileSync(`${xmlFolder}/NoAgreementError.xml`).toString();
-
-      const rsp = await uParser.parse(xml);
       try {
-        errorHandler.call(uParser, uParser.mergeLeafRecursive(rsp['SOAP:Fault'][0]));
-        throw new Error('Skipped NoAgreement error!');
+        await getParseResponse(
+          'air:AirRetrieveDocumentRsp', 'NoAgreementError.xml',
+          airParser.AIR_GET_TICKETS, airParser.AIR_GET_TICKETS_ERROR_HANDLER
+        );
+        throw new Error('Skipped error!');
       } catch (err) {
         expect(err).to.be.an.instanceof(AirRuntimeError.NoAgreement);
         expect(err.data.pcc).to.be.equal('7J8J');
       }
     });
     it('should correctly handle other errors', async () => {
-      const uParser = new Parser('air:AirRetrieveDocumentRsp', 'v47_0', {});
-      const errorHandler = airParser.AIR_GET_TICKETS_ERROR_HANDLER;
-      const xml = fs.readFileSync(`${xmlFolder}/AirGetTickets-error-general.xml`).toString();
-
-      const rsp = await uParser.parse(xml);
       try {
-        errorHandler.call(uParser, uParser.mergeLeafRecursive(rsp['SOAP:Fault'][0]));
-        throw new Error('Skipped NoAgreement error!');
+        await getParseResponse(
+          'air:AirRetrieveDocumentRsp', 'AirGetTickets-error-general.xml',
+          airParser.AIR_GET_TICKETS, airParser.AIR_GET_TICKETS_ERROR_HANDLER
+        );
+        throw new Error('Skipped error!');
       } catch (err) {
         expect(err).to.be.an.instanceof(RequestRuntimeError.UnhandledError);
       }


### PR DESCRIPTION
- getTickets now checks for access to PNR
- getTickets now throw NoAgreement error, when there is no access to PNR
- Correct error detection for error code 1512 NoAgreement/UnableToRetrieve