### PR TITLE
Added overrideContinuityCheck to book() to allow openjaw bookings

### DIFF
--- a/docs/Air.md
+++ b/docs/Air.md
@@ -128,6 +128,8 @@ After searching for air segments and fares, air bookings are created using the r
 | deliveryInformation | `Delivery Information` | Optional. See `Delivery Information` description [below](#delivery-info). |
 | tau | `String`/`Date`/`Array<Number>` | Optional. Takes  See `TAU` description [below](#tau). The default value is 3 hours from the current timestamp.|
 | platingCarrier | `String` | Optional. PlatingCarrier. |
+| overrideContinuityCheck | `Boolean` | Optional. Sets ContinuityCheckOverride. |
+
 
 ### Segment object
 <a name="segment"></a>

--- a/src/Services/Air/templates/AIR_CREATE_RESERVATION_REQUEST.handlebars.js
+++ b/src/Services/Air/templates/AIR_CREATE_RESERVATION_REQUEST.handlebars.js
@@ -67,7 +67,7 @@ module.exports = `
             </com:BookingTraveler>
             {{/each}}
 
-            {{#if overrideContinuityCheck}}<air:ContinuityCheckOverride>yes</air:ContinuityCheckOverride>{{/if}}
+            {{#if overrideContinuityCheck}}<com:ContinuityCheckOverride>yes</com:ContinuityCheckOverride>{{/if}}
 
             <air:AirPricingSolution {{#each air:AirPricingSolution}}{{@key}}="{{{this}}}" {{/each}}>
                 {{{air:AirPricingSolution_XML.air:AirSegment_XML}}}

--- a/src/Services/Air/templates/AIR_CREATE_RESERVATION_REQUEST.handlebars.js
+++ b/src/Services/Air/templates/AIR_CREATE_RESERVATION_REQUEST.handlebars.js
@@ -67,6 +67,8 @@ module.exports = `
             </com:BookingTraveler>
             {{/each}}
 
+            {{#if overrideContinuityCheck}}<air:ContinuityCheckOverride />{{/if}}
+
             <air:AirPricingSolution {{#each air:AirPricingSolution}}{{@key}}="{{{this}}}" {{/each}}>
                 {{{air:AirPricingSolution_XML.air:AirSegment_XML}}}
                 {{{air:AirPricingSolution_XML.air:AirPricingInfo_XML}}}

--- a/src/Services/Air/templates/AIR_CREATE_RESERVATION_REQUEST.handlebars.js
+++ b/src/Services/Air/templates/AIR_CREATE_RESERVATION_REQUEST.handlebars.js
@@ -67,7 +67,7 @@ module.exports = `
             </com:BookingTraveler>
             {{/each}}
 
-            {{#if overrideContinuityCheck}}<air:ContinuityCheckOverride />{{/if}}
+            {{#if overrideContinuityCheck}}<air:ContinuityCheckOverride>yes</air:ContinuityCheckOverride>{{/if}}
 
             <air:AirPricingSolution {{#each air:AirPricingSolution}}{{@key}}="{{{this}}}" {{/each}}>
                 {{{air:AirPricingSolution_XML.air:AirSegment_XML}}}


### PR DESCRIPTION
UAPI doesn't automagically add ARNK when we book for open jaw or many other cases. And booking will return "Segment continuity validation failed."

Adding "ContinuityCheckOverride" will allow agent to bypass the continuity check without adding ARNKs.

This PR is related to #451