### PR TITLE
Correctly handle missing of AirAvailInfo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uapi-json",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uapi-json",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Travelport Universal API",
   "main": "src/",
   "files": [

--- a/src/Services/Air/AirParser.js
+++ b/src/Services/Air/AirParser.js
@@ -1336,7 +1336,8 @@ function availability(rsp) {
   itinerarySolution['air:AirSegmentRef'].forEach((segmentRef, key) => {
     const segment = rsp['air:AirSegmentList'][segmentRef];
     const isConnected = connectedSegments.find(s => s === key);
-    const availInfo = segment['air:AirAvailInfo'].find(info => info.ProviderCode === this.provider);
+    const availInfoList = segment['air:AirAvailInfo'] || [];
+    const availInfo = availInfoList.find(info => info.ProviderCode === this.provider);
 
     if (!availInfo) {
       return;


### PR DESCRIPTION
When UAPI responses with no `air:AirAvailInfo` property of a Segment we get an error.